### PR TITLE
bugfixes (memory error) and enhancement (overwrite option)

### DIFF
--- a/src/imc_cli.c
+++ b/src/imc_cli.c
@@ -38,6 +38,7 @@ static const struct argp_option argp_options[] = {
         "This option can be used with '--hide', '--extract', or '--check'." , 4},
     {"verbose", 'v', NULL, 0, "Print detailed progress information.", 5},
     {"silent", 's', NULL, 0, "Do not print any progress information (errors are still shown).", 5},
+	{"overwrite", 'f', NULL, 0, "Overwrite existing output files instead of renaming them.", 3}, // GG Added option to overwrite output file or payload if already present
     {"algorithm", PRINT_ALGORITHM, NULL, 0, "Print a summary of the algorithm used by imgconceal, then exit.", 6},
     {0}
 };
@@ -103,6 +104,7 @@ typedef struct UserOptions {
     bool no_password;   // 'true' if not using a password
     bool verbose;       // Prints detailed information during operation
     bool silent;        // Do not print any information during operation
+	bool overwrite; // GG Added option to overwrite output file or payload if already present
 } UserOptions;
 
 // Get a password from the user on the command-line. The typed characters are not displayed.
@@ -681,7 +683,7 @@ static inline void __execute_options(struct argp_state *state, void *options)
         int unhide_status = IMC_SUCCESS;
         while (unhide_status == IMC_SUCCESS)
         {
-            unhide_status = imc_steg_extract(steg_image);
+            unhide_status = imc_steg_extract(steg_image, opt->overwrite); // GG Added option to overwrite output file or payload if already present
             const char const* image_name = basename(steg_path); // Name of the image with hidden data
             const char const* unhid_name = steg_image->steg_info->file_name; // Name of the unhidden file
 
@@ -819,7 +821,7 @@ static inline void __execute_options(struct argp_state *state, void *options)
     if (mode == HIDE && image_has_changed)
     {
         const char *const save_path = opt->output ? opt->output : opt->input;
-        const int save_status = imc_steg_save(steg_image, save_path);
+        const int save_status = imc_steg_save(steg_image, save_path, opt->overwrite); // GG Added option to overwrite output file or payload if already present
         /* Note: The input image will not be overwritten because our file name
            collision resolution is going to append a number to the output's name. */
         
@@ -924,6 +926,11 @@ static int imc_cli_parse_options(int key, char *arg, struct argp_state *state)
             ((UserOptions*)(state->hook))->append = true;
             break;
         
+        // --overwrite: Overwrite existing output files // GG Added option to overwrite output file or payload if already present
+		case 'f': // GG Added option to overwrite output file or payload if already present
+			((UserOptions*)(state->hook))->overwrite = true; // GG Added option to overwrite output file or payload if already present
+			break; // GG Added option to overwrite output file or payload if already present
+
         // --password: Password provided by the user
         case 'p':
             if (((UserOptions*)(state->hook))->no_password)

--- a/src/imc_image_io.c
+++ b/src/imc_image_io.c
@@ -428,7 +428,8 @@ static bool __read_payload(CarrierImage *carrier_img, size_t num_bytes, uint8_t 
 // So in order to extract all the hidden files, it should be called
 // until it stops returning the IMC_SUCCESS status code.
 // Note: The filename is stored with the hidden data
-int imc_steg_extract(CarrierImage *carrier_img)
+int imc_steg_extract(CarrierImage *carrier_img, bool overwrite) // GG Added option to overwrite output file or payload if already present
+// GG int imc_steg_extract(CarrierImage *carrier_img)
 {
     bool read_status;
     
@@ -648,9 +649,11 @@ int imc_steg_extract(CarrierImage *carrier_img)
         is to restore the file as close to the original as possible.
     */
     
-    // Make the filename unique (if it already isn't)
-    bool is_unique = __resolve_filename_collision(file_name);
-    if (!is_unique) return IMC_ERR_FILE_EXISTS;
+    // Make the filename unique (if it already isn't) // GG Added option to overwrite output file or payload if already present
+	if (!overwrite) { // GG Added option to overwrite output file or payload if already present
+	    bool is_unique = __resolve_filename_collision(file_name);
+    	if (!is_unique) return IMC_ERR_FILE_EXISTS;
+	} // GG Added option to overwrite output file or payload if already present
 
     // Write the hidden file to disk
     FILE *out_file = fopen(file_name, "wb");
@@ -1443,7 +1446,8 @@ static void __jpeg_write_callback(j_common_ptr jpeg_obj)
 }
 
 // Write the carrier bytes back to the JPEG image, and save it as a new file
-int imc_jpeg_carrier_save(CarrierImage *carrier_img, const char *save_path)
+int imc_jpeg_carrier_save(CarrierImage *carrier_img, const char *save_path, bool overwrite) // GG Added option to overwrite output file or payload if already present
+// int imc_jpeg_carrier_save(CarrierImage *carrier_img, const char *save_path) // GG Added option to overwrite output file or payload if already present
 {
     // Append the '.jpg' extension to the path, if it does not already end in '.jpg' or '.jpeg'
     const size_t p_len = strlen(save_path);
@@ -1463,9 +1467,11 @@ int imc_jpeg_carrier_save(CarrierImage *carrier_img, const char *save_path)
     // Append a number to the file's stem if the filename already exists
     // Example: 'Image.jpg' might become 'Image (1).jpg'
     // Note: The number goes up to 99, in order to avoid creating too many files accidentally
-    bool is_unique = __resolve_filename_collision(jpeg_path);
-    if (!is_unique) return IMC_ERR_FILE_EXISTS;
-
+	if (!overwrite) { // GG Added option to overwrite output file or payload if already present
+		bool is_unique = __resolve_filename_collision(jpeg_path);
+	    if (!is_unique) return IMC_ERR_FILE_EXISTS;
+	} // GG Added option to overwrite output file or payload if already present
+	
     // Store a copy of the resulting path
     free(carrier_img->out_path);
     carrier_img->out_path = strdup(jpeg_path);
@@ -1610,7 +1616,9 @@ static void __png_write_callback(png_structp png_obj, png_uint_32 row, int pass)
 }
 
 // Write the carrier bytes back to the PNG image, and save it as a new file
-int imc_png_carrier_save(CarrierImage *carrier_img, const char *save_path)
+// GG Added option to overwrite output file or payload if already present
+int imc_png_carrier_save(CarrierImage *carrier_img, const char *save_path, bool overwrite)
+// int imc_png_carrier_save(CarrierImage *carrier_img, const char *save_path) // GG Added option to overwrite output file or payload if already present
 {
     // Append the '.png' extension to the path, if it does not already has the extension
     const size_t p_len = strlen(save_path);
@@ -1626,9 +1634,11 @@ int imc_png_carrier_save(CarrierImage *carrier_img, const char *save_path)
     // Append a number to the file's stem if the filename already exists
     // Example: 'Image.png' might become 'Image (1).png'
     // Note: The number goes up to 99, in order to avoid creating too many files accidentally
-    bool is_unique = __resolve_filename_collision(png_path);
-    if (!is_unique) return IMC_ERR_FILE_EXISTS;
-
+	if (!overwrite) { // GG Added option to overwrite output file or payload if already present
+		bool is_unique = __resolve_filename_collision(png_path);
+	    if (!is_unique) return IMC_ERR_FILE_EXISTS;
+	} // GG Added option to overwrite output file or payload if already present
+	
     // Store a copy of the resulting path
     free(carrier_img->out_path);
     carrier_img->out_path = strdup(png_path);
@@ -1891,7 +1901,9 @@ static int __webp_write_callback(int percent, const WebPPicture* webp_obj)
 }
 
 // Write the carrier bytes back to the WebP image, and save it as a new file
-int imc_webp_carrier_save(CarrierImage *carrier_img, const char *save_path)
+// GG Added option to overwrite output file or payload if already present
+int imc_webp_carrier_save(CarrierImage *carrier_img, const char *save_path, bool overwrite) // GG Added option to overwrite output file or payload if already present
+// GG int imc_webp_carrier_save(CarrierImage *carrier_img, const char *save_path) // GG Added option to overwrite output file or payload if already present
 {
     // Append the '.webp' extension to the path, if it does not already has the extension
     const size_t p_len = strlen(save_path);
@@ -1907,8 +1919,10 @@ int imc_webp_carrier_save(CarrierImage *carrier_img, const char *save_path)
     // Append a number to the file's stem if the filename already exists
     // Example: 'Image.webp' might become 'Image (1).webp'
     // Note: The number goes up to 99, in order to avoid creating too many files accidentally
-    bool is_unique = __resolve_filename_collision(webp_path);
-    if (!is_unique) return IMC_ERR_FILE_EXISTS;
+	if (!overwrite) { // GG Added option to overwrite output file or payload if already present
+	    bool is_unique = __resolve_filename_collision(webp_path);
+	    if (!is_unique) return IMC_ERR_FILE_EXISTS;
+	} // GG Added option to overwrite output file or payload if already present
 
     // Store a copy of the resulting path
     free(carrier_img->out_path);
@@ -2090,9 +2104,11 @@ void imc_webp_carrier_close(CarrierImage *carrier_img)
 }
 
 // Save the image with hidden data
-int imc_steg_save(CarrierImage *carrier_img, const char *save_path)
+// GG Added option to overwrite output file or payload if already present
+int imc_steg_save(CarrierImage *carrier_img, const char *save_path, bool overwrite)
+// GG int imc_steg_save(CarrierImage *carrier_img, const char *save_path) // GG Added option to overwrite output file or payload if already present
 {
-    return carrier_img->save(carrier_img, save_path);
+    return carrier_img->save(carrier_img, save_path, overwrite); // GG Added option to overwrite output file or payload if already present
 }
 
 // Free the memory of the data structures used for steganography

--- a/src/imc_image_io.c
+++ b/src/imc_image_io.c
@@ -263,8 +263,14 @@ int imc_steg_insert(CarrierImage *carrier_img, const char *file_path)
 
     // Create a buffer for the compressed data
     // Note: For the overhead calculation, see https://zlib.net/zlib_tech.html
-    const size_t zlib_overhead = 6 + (5 * (file_size / 16000)) + 1;
-    size_t zlib_buffer_size = raw_size + zlib_overhead;
+    // GG This two lines were commented to fix a bug causing a "memory"
+    // GG error when hidden file was already compressed, encrypted or high entropy
+    // GG const size_t zlib_overhead = 6 + (5 * (file_size / 16000)) + 1;
+    // GG size_t zlib_buffer_size = raw_size + zlib_overhead;
+    // GG This two lines are part of the fix above
+    const uLong uncompressed_size = (uLong)(raw_size - compressed_offset); // GG
+	size_t zlib_buffer_size = compressed_offset + compressBound(uncompressed_size); // GG
+
     uint8_t *const input_buffer = (uint8_t *)(&file_info->access_time);
     uint8_t *zlib_buffer = imc_malloc(zlib_buffer_size);
     
@@ -292,7 +298,8 @@ int imc_steg_insert(CarrierImage *carrier_img, const char *file_path)
         &zlib_buffer_size,                  // Size in bytes of the output buffer (the function updates the value to the used size)
         #endif // _WIN32
         input_buffer,                       // Data being compressed
-        file_info->uncompressed_size,       // Size in bytes of the data
+        // GG file_info->uncompressed_size,       // Size in bytes of the data
+    	uncompressed_size, // GG Size in bytes of the data see fix above marked GG
         9                                   // Compression level
     );
 

--- a/src/imc_image_io.h
+++ b/src/imc_image_io.h
@@ -46,7 +46,7 @@ enum ImageType {IMC_JPEG, IMC_PNG, IMC_WEBP};
 // Pointers to the steganographic functions
 struct CarrierImage;
 typedef void (*carrier_open_func)(struct CarrierImage *);
-typedef int (*carrier_save_func)(struct CarrierImage *, const char *save_path);
+typedef int (*carrier_save_func)(struct CarrierImage *, const char *save_path, bool overwrite); // GG Added option to overwrite output file or payload if already present
 typedef void (*carrier_close_func)(struct CarrierImage *);
 
 // Image that will carry the hidden data
@@ -147,7 +147,7 @@ static bool __read_payload(CarrierImage *carrier_img, size_t num_bytes, uint8_t 
 // So in order to extract all the hidden files, it should be called
 // until it stops returning the IMC_SUCCESS status code.
 // Note: The filename is stored with the hidden data
-int imc_steg_extract(CarrierImage *carrier_img);
+int imc_steg_extract(CarrierImage *carrier_img, bool overwrite); // GG Added option to overwrite output file or payload if already present
 
 // Move the read position of the carrier bytes to right after the end of the last hidden file
 // Note: this function is intended to be used when in "append mode" while hiding a file.
@@ -183,19 +183,19 @@ static void __copy_file_times(FILE *source_file, const char *dest_path);
 static void __jpeg_write_callback(j_common_ptr jpeg_obj);
 
 // Write the carrier bytes back to the JPEG image, and save it as a new file
-int imc_jpeg_carrier_save(CarrierImage *carrier_img, const char *save_path);
+int imc_jpeg_carrier_save(CarrierImage *carrier_img, const char *save_path, bool overwrite); // GG Added option to overwrite output file or payload if already present
 
 // Progress monitor when writing a PNG image
 static void __png_write_callback(png_structp png_obj, png_uint_32 row, int pass);
 
 // Write the carrier bytes back to the PNG image, and save it as a new file
-int imc_png_carrier_save(CarrierImage *carrier_img, const char *save_path);
+int imc_png_carrier_save(CarrierImage *carrier_img, const char *save_path, bool overwrite); // GG Added option to overwrite output file or payload if already present
 
 // Progress monitor when writing a PNG image
 static int __webp_write_callback(int percent, const WebPPicture* webp_obj);
 
 // Write the carrier bytes back to the WebP image, and save it as a new file
-int imc_webp_carrier_save(CarrierImage *carrier_img, const char *save_path);
+int imc_webp_carrier_save(CarrierImage *carrier_img, const char *save_path, bool overwrite); // GG Added option to overwrite output file or payload if already present
 
 // Free the memory of the array of heap pointers in a CarrierImage struct
 static void __carrier_heap_free(CarrierImage *carrier_img);
@@ -210,7 +210,7 @@ void imc_png_carrier_close(CarrierImage *carrier_img);
 void imc_webp_carrier_close(CarrierImage *carrier_img);
 
 // Save the image with hidden data
-int imc_steg_save(CarrierImage *carrier_img, const char *save_path);
+int imc_steg_save(CarrierImage *carrier_img, const char *save_path, bool overwrite); // GG Added option to overwrite output file or payload if already present
 
 // Free the memory of the data structures used for steganography
 void imc_steg_finish(CarrierImage *carrier_img);


### PR DESCRIPTION
Fix a bug causing a "memory" error when hidden file was already compressed, encrypted or high entropy
Implemented new "overwrite" option to Overwrite existing output files or payload instead of renaming them.